### PR TITLE
fix(api): ensure custom apiKey is passed to Groq service functions

### DIFF
--- a/app/api/groq/route.ts
+++ b/app/api/groq/route.ts
@@ -41,6 +41,7 @@ export async function POST(request: NextRequest) {
           tone: updatedOptions?.tone,
           characters: updatedOptions?.characters,
           setting: updatedOptions?.setting,
+          apiKey: updatedOptions?.apiKey,
         });
         break;
       case 'analyze':


### PR DESCRIPTION
## 📝 Description

**Issue Reference:** #221 

## 🏗️ Type of Change
Select the relevant categories:
- [ x ] 🤖 **AI/Prompt Logic** (Changes to Groq API integration )

---
### Problem
The API accepts an `apiKey` parameter in the request body and creates `updatedOptions`,
but this object was never used when calling Groq service functions.
As a result, custom API keys provided by users were ignored and the default key was always used.

### Solution
This PR updates the API route to consistently use `updatedOptions` when extracting
story generation options (tone, characters, setting), ensuring that a provided `apiKey`
is correctly propagated to downstream Groq service calls.

### Impact
- Enables support for custom API keys
- Preserves existing behavior when no `apiKey` is provided
- Fixes a silent configuration bug without breaking the API


_By submitting this PR, I agree to maintain the decentralized and open-source spirit of GroqTales. 📖✨_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generation requests now correctly merge API key with generation options and forward the key along with tone, characters, and setting, ensuring configured security and expected behavior when making generation requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->