### PR TITLE
fix(nft): make like button interactive on story cards

### DIFF
--- a/components/profile/story-card.tsx
+++ b/components/profile/story-card.tsx
@@ -20,12 +20,9 @@ export function StoryCard({ story }: { story: StoryProps }) {
   const [likeCount, setLikeCount] = useState(story.likes);
 
   const handleLike = () => {
-  setLiked((prevLiked) => {
-    setLikeCount((prevCount) =>
-      prevLiked ? prevCount - 1 : prevCount + 1
-    );
-    return !prevLiked;
-  });
+  const nextLiked = !liked;
+  setLiked(nextLiked);
+  setLikeCount((prev) => prev + (nextLiked ? 1 : -1));
 };
   return (
     <Card className="group overflow-hidden border-slate-800 bg-slate-950 hover:border-slate-600 transition-all duration-300 hover:shadow-2xl hover:shadow-violet-900/10">
@@ -59,10 +56,13 @@ export function StoryCard({ story }: { story: StoryProps }) {
       
       <CardFooter className="p-4 pt-2 flex justify-between items-center text-slate-500 text-sm">
         <div className="flex gap-4">
-          <button type="button"
-                  onClick={handleLike}
-                  className={`flex items-center gap-1 transition-colors ${
-                  liked ? "text-pink-500" : "text-slate-500 hover:text-pink-400"}`} aria-label="Like story">
+         <button
+    type="button"
+    onClick={handleLike}
+    aria-label={liked ? "Unlike story" : "Like story"}
+    aria-pressed={liked}
+    className={`flex items-center gap-1 transition-colors ${
+    liked ? "text-pink-500" : "text-slate-500 hover:text-pink-400"}`}>
   <Heart
     aria-hidden="true"
     className={`w-4 h-4 transition ${


### PR DESCRIPTION
## 📝 Description

**Issue Reference:** #291 

## 🏗️ Type of Change
Select the relevant categories:
- [ x ] 🎨 **Frontend/UI** (Next.js, Tailwind, or Shadcn components)

---
### Problem
On the NFT listing page, the Like button inside each story card was not functional.
Clicking the heart icon did not trigger any UI update, change the like count, or provide visual feedback.

### Solution
- Added local state to track liked/unliked status
- Implemented a click handler for the Like button
- Updated the UI to reflect the active/inactive like state
- Synced the displayed like count with user interaction
- Converted the non-interactive element into an accessible button

### Result
Users now receive immediate visual feedback when liking or unliking a story,
and the like count updates correctly.

### Notes
This PR focuses on fixing the frontend interaction and UI behavior.
Backend/API persistence can be added in a follow-up PR if required.

---

_By submitting this PR, I agree to maintain the decentralized and open-source spirit of GroqTales. 📖✨_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Story cards now include an interactive Like button allowing users to like/unlike stories with immediate visual feedback (heart icon and color changes).
  * Like counts update dynamically and are displayed next to the Like button for real-time engagement visibility.
  * Accessibility enhancements added to the Like control for improved support with assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->