### PR TITLE
fix: replace alert with custom install modal for better UX

### DIFF
--- a/components/providers/web3-provider.tsx
+++ b/components/providers/web3-provider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
-
+import { X, Download } from 'lucide-react';
 // Mock Web3 Provider for production deployment
 interface Web3ContextType {
   account: string | null;
@@ -90,6 +90,7 @@ export function Web3Provider({ children }: { children: React.ReactNode }) {
   const [connecting, setConnecting] = useState(false);
   const [networkName, setNetworkName] = useState('Unknown');
   const [ensName, setEnsName] = useState<string | null>(null);
+  const [showInstallModal, setShowInstallModal] = useState(false);
 
   useEffect(() => {
     if (typeof window !== 'undefined' && (window as any).ethereum) {
@@ -141,7 +142,7 @@ export function Web3Provider({ children }: { children: React.ReactNode }) {
         setConnecting(false);
       }
     } else {
-      alert('Please install MetaMask!');
+      setShowInstallModal(true);
     }
   };
 
@@ -229,7 +230,43 @@ export function Web3Provider({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <Web3Context.Provider value={contextValue}>{children}</Web3Context.Provider>
+    <Web3Context.Provider value={contextValue}>
+      {children}
+      
+      {showInstallModal && (
+        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+          <div className="bg-white dark:bg-slate-900 border-2 border-black dark:border-white rounded-xl shadow-lg max-w-sm w-full p-6 relative">
+            <button 
+              onClick={() => setShowInstallModal(false)}
+              className="absolute top-4 right-4 text-gray-500 hover:text-black dark:hover:text-white"
+            >
+              <X className="w-5 h-5" />
+            </button>
+
+            <div className="flex flex-col items-center text-center space-y-4">
+              <div className="w-12 h-12 bg-orange-100 rounded-full flex items-center justify-center">
+                <Download className="w-6 h-6 text-orange-600" />
+              </div>
+              
+              <h3 className="text-xl font-bold dark:text-white">Install MetaMask</h3>
+              <p className="text-gray-600 dark:text-gray-300 text-sm">
+                You need a crypto wallet to log in.
+              </p>
+
+              <a 
+                href="https://metamask.io/download" 
+                target="_blank" 
+                rel="noopener noreferrer"
+                onClick={() => setShowInstallModal(false)}
+                className="w-full bg-orange-500 hover:bg-orange-600 text-white font-bold py-3 rounded-lg flex items-center justify-center gap-2"
+              >
+                Download Extension
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
+      </Web3Context.Provider>
   );
 }
 


### PR DESCRIPTION
**Description**

I replaced the native alert() which was causing user confusion.
Issue Reference: Fixes #306
## 🏗️ Type of Change
What I Changed:
- Replaced the generic alert with a Custom Modal UI using Tailwind CSS.
- Added a direct "Download Extension" button that links to MetaMask.io.

Why a Modal? 

- I initially attempted to use a Toast notification, but I upgraded to a Modal because:
- It guarantees visibility (fixed z-index issues).


It demands user attention, preventing them from missing the "Install" instruction.
Select the relevant categories:
- [ ] 🤖 **AI/Prompt Logic** (Changes to Groq API integration or story prompts)
- [ ] ⛓️ **Web3/Smart Contracts** (Solidity, Monad SDK, or Minting logic)
- [x] 🎨 Frontend/UI (Next.js, Tailwind, or Shadcn components)
- [ ] 📄 **Documentation** (README, Wiki, or Code comments)
- [x] 🐛 Bug Fix (Functional or security repair)

---

## ⚙️ Technical Checklist
- [ ] **AI Testing:** I have tested Story Generation with a valid `GROQ_API_KEY`.
- [ ] **Web3 Verification:** (If applicable) I have verified contract logic on the **Monad Testnet**.
- [x] UI Standards: My changes follow the Progressive Disclosure (accordion-based) design.
- [x] Security: I have ensured no Private Keys or .env files are being committed.
- [x] Code Quality: My code is linted and follows the project's modular structure.
---

## 🧪 Testing Evidence
Manual Verification:
1. Validated that clicking "Login" without MetaMask triggers the new Modal.
2. Verified the "Download Extension" button redirects to the correct URL.
3. Verified the "Close" button functions correctly.

## 📸 Visual Proof
### **Before:**
![WhatsApp Image 2026-02-10 at 23 21 05](https://github.com/user-attachments/assets/fdc94884-f926-4f24-b21f-9514b37e1c26)
### **After:**
![WhatsApp Image 2026-02-10 at 23 20 24](https://github.com/user-attachments/assets/29750b46-a9bd-44ae-aa61-1b5a3498b7cd)

---

## ❄️ SWOC '26 Status
* [x] I am an official contributor for Social Winter of Code 2026.

---

_By submitting this PR, I agree to maintain the decentralized and open-source spirit of GroqTales. 📖✨_
