### PR TITLE
fix: social icons visibility issue on hover in light mode

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -97,7 +97,7 @@ export function Footer() {
                     href={link.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="p-3 border-4 border-foreground dark:border-slate-700 bg-card dark:bg-slate-900 hover:bg-primary hover:border-primary  transition-all duration-300 shadow-[4px_4px_0px_0px_var(--shadow-color)] hover:-translate-y-1 hover:shadow-[6px_6px_0px_0px_var(--shadow-color)] group"
+                    className="p-3 border-4 border-foreground dark:border-slate-700 bg-card dark:bg-slate-900 hover:bg-primary hover:border-primary transition-all duration-300 shadow-[4px_4px_0px_0px_var(--shadow-color)] hover:-translate-y-1 hover:shadow-[6px_6px_0px_0px_var(--shadow-color)] group"
                     aria-label={link.label}
                   >
                     <span className="block group-hover:scale-110 transition-transform duration-300">


### PR DESCRIPTION
- Fixed hover visibility issue of social icons in light mode
- Icons were becoming hard to see due to hover text color changes
- Removed conflicting hover text styles
- Preserved lift and shadow hover effects
- Improves UI consistency across light and dark themes

Fixes #340 

https://github.com/user-attachments/assets/7c8fd7c9-b3d7-4a24-b805-ea4bad345326




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted the footer social link hover styling to remove the previous white hover color.
  * This update refines hover contrast and visual consistency across the footer, improving readability and the overall polished look of the site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->