### PR TITLE
feat: implement ai remix story functionality (Fixes #413)

### DIFF
--- a/app/create/ai-story/page.tsx
+++ b/app/create/ai-story/page.tsx
@@ -128,9 +128,9 @@ function AIStoryContent() {
                 <Sparkles className="w-4 h-4 text-emerald-400" />
                 <span className="text-xs font-medium tracking-wider uppercase text-white/80">Groq AI Studio</span>
               </motion.div>
-              
+
               <h1 className="text-5xl md:text-7xl font-bold tracking-tighter mb-4 text-transparent bg-clip-text bg-gradient-to-r from-white via-white/90 to-white/50">
-                Architect Your <br className="hidden md:block"/> Universe
+                Architect Your <br className="hidden md:block" /> Universe
               </h1>
               <p className="text-lg text-white/50 max-w-xl leading-relaxed">
                 Configure your narrative parameters below. Our neural engine will synthesize your specifications into a cohesive, mintable legacy.
@@ -157,7 +157,11 @@ function AIStoryContent() {
           <div className="relative">
             {/* Subtle glow behind the generator */}
             <div className="absolute inset-0 bg-gradient-to-br from-emerald-500/5 to-purple-500/5 blur-3xl -z-10 rounded-[3rem]" />
-            <AIStoryGenerator className="relative z-10" />
+            <AIStoryGenerator
+              className="relative z-10"
+              initialPrompt={searchParams.get('prompt') || ''}
+              initialGenre={searchParams.get('genre') || ''}
+            />
           </div>
 
         </div>

--- a/components/ai-story-generator.tsx
+++ b/components/ai-story-generator.tsx
@@ -49,6 +49,8 @@ import { truncateAddress } from '@/lib/utils';
 
 interface AIStoryGeneratorProps {
   className?: string;
+  initialPrompt?: string;
+  initialGenre?: string;
 }
 
 const DRAFT_KEY = "groqtales_story_draft_v1";
@@ -108,12 +110,14 @@ interface StoryDraft {
 
 export default function AIStoryGenerator({
   className = '',
+  initialPrompt = '',
+  initialGenre = '',
 }: AIStoryGeneratorProps) {
   // Core required fields
-  const [prompt, setPrompt] = useState('');
+  const [prompt, setPrompt] = useState(initialPrompt);
 
   // Core optional fields
-  const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
+  const [selectedGenres, setSelectedGenres] = useState<string[]>(initialGenre ? [initialGenre] : []);
   const [storyLength, setStoryLength] = useState('medium');
   const [storyTitle, setStoryTitle] = useState('');
 
@@ -949,8 +953,8 @@ export default function AIStoryGenerator({
                                 key={trait}
                                 onClick={() => toggleTrait(trait)}
                                 className={`px-3 py-1 rounded-md border-2 border-black text-sm font-bold transition-all ${characterTraits.includes(trait)
-                                    ? 'bg-blue-400 text-white'
-                                    : 'bg-white/5 text-white hover:bg-white/5'
+                                  ? 'bg-blue-400 text-white'
+                                  : 'bg-white/5 text-white hover:bg-white/5'
                                   }`}
                               >
                                 {trait}
@@ -1568,8 +1572,8 @@ export default function AIStoryGenerator({
                                 key={theme}
                                 onClick={() => toggleTheme(theme.toLowerCase())}
                                 className={`px-3 py-1 rounded-md border-2 border-black text-sm font-bold transition-all ${secondaryThemes.includes(theme.toLowerCase())
-                                    ? 'bg-pink-400 text-white'
-                                    : 'bg-white/5 text-white hover:bg-white/5'
+                                  ? 'bg-pink-400 text-white'
+                                  : 'bg-white/5 text-white hover:bg-white/5'
                                   }`}
                               >
                                 {theme}
@@ -1925,8 +1929,8 @@ export default function AIStoryGenerator({
                                   }
                                 }}
                                 className={`px-3 py-1 rounded-md border-2 border-black text-sm font-bold transition-all ${avoidCliches.includes(trope.toLowerCase())
-                                    ? 'bg-rose-500/20 text-rose-300 text-white'
-                                    : 'bg-white/5 text-white hover:bg-white/5'
+                                  ? 'bg-rose-500/20 text-rose-300 text-white'
+                                  : 'bg-white/5 text-white hover:bg-white/5'
                                   }`}
                               >
                                 {trope}
@@ -1966,8 +1970,8 @@ export default function AIStoryGenerator({
                                   }
                                 }}
                                 className={`px-3 py-1 rounded-md border-2 border-black text-sm font-bold transition-all ${includeTropes.includes(trope.toLowerCase())
-                                    ? 'bg-green-400 text-white'
-                                    : 'bg-white/5 text-white hover:bg-white/5'
+                                  ? 'bg-green-400 text-white'
+                                  : 'bg-white/5 text-white hover:bg-white/5'
                                   }`}
                               >
                                 {trope}

--- a/components/story-details-dialog.tsx
+++ b/components/story-details-dialog.tsx
@@ -5,9 +5,11 @@ import {
   Share2,
   Wallet,
   ShoppingCart,
+  Sparkles,
 } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import * as React from 'react';
 
 import { useWeb3 } from '@/components/providers/web3-provider';
@@ -48,6 +50,24 @@ export default function StoryDetailsDialog({
   const [commentCount, setCommentCount] = React.useState(
     story.comments?.length || 0
   );
+  const router = useRouter();
+
+  const handleRemix = () => {
+    onClose();
+
+    // Convert current story content into a context prompt
+    const contentToRemix = story.content || story.description || '';
+    const remixPrompt = `Remix this story: ${contentToRemix.substring(0, 1500)}`; // Trim to avoid URL length issues
+
+    const query = new URLSearchParams({
+      remix: 'true',
+      source: 'story',
+      genre: story.genre || 'Fantasy',
+      prompt: remixPrompt,
+    });
+
+    router.push(`/create/ai-story?${query.toString()}`);
+  };
 
   const handlePurchase = () => {
     if (!account) {
@@ -165,6 +185,15 @@ export default function StoryDetailsDialog({
                 <Button variant="ghost" size="sm">
                   <Share2 className="w-4 h-4 mr-1" />
                   Share
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleRemix}
+                  className="text-emerald-500 hover:text-emerald-600 hover:bg-emerald-500/10"
+                >
+                  <Sparkles className="w-4 h-4 mr-1" />
+                  Remix
                 </Button>
               </div>
               <div className="flex items-center space-x-2">


### PR DESCRIPTION
## Description
Implements Issue #413 by adding an AI "Remix" feature, dramatically increasing community engagement by allowing users to effortlessly generate spin-offs or variations of stories they find on the platform.

## Changes Made
* **Story Details Action**: Integrated a new "Remix" button (featuring the `Sparkles` icon) directly adjacent to the existing `Like` and `Share` actions in `components/story-details-dialog.tsx`.
* **State Parsing**: Configured `story-details-dialog.tsx` to encode the original story's context (truncated to 1500 chars) and genre as URL `searchParams`, routing seamlessly to the `/create/ai-story` hub.
* **Component Initialization**: 
  * Updated `app/create/ai-story/page.tsx`'s `<Suspense>` wrapper to catch the `genre` and `prompt` parameters from the URL payload and feed them downwards as explicit React props.
  * Overhauled `components/ai-story-generator.tsx`'s underlying `useState` declarations. It now conditionally leverages `initialPrompt` and `initialGenre` if spawned from a remix intent, seamlessly bypassing traditional empty-state loading to present the author immediately with a pre-configured studio ready for generation.



Fixes #413


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "Remix" button in story details that enables users to quickly create variations of existing stories, with genre and creative parameters automatically pre-filled.
  * The story generator now accepts and displays pre-populated initial prompts and genre selections when accessed through navigation, streamlining the creative iteration workflow for users building upon existing stories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->